### PR TITLE
Feature/sign up 회원가입 시 관리자 자동 배정하기

### DIFF
--- a/salarying/src/main/java/com/example/salarying/Admin/User/repository/AdminRepository.java
+++ b/salarying/src/main/java/com/example/salarying/Admin/User/repository/AdminRepository.java
@@ -3,6 +3,7 @@ package com.example.salarying.Admin.User.repository;
 import com.example.salarying.Admin.User.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
@@ -10,4 +11,8 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
     Optional<Admin> findByAdminEmail(String email);
 
     Optional<Admin> findAdminById(Long Id);
+
+    Admin findByRole(String role);
+
+    List<Admin> findAllByRole(String role);
 }

--- a/salarying/src/main/java/com/example/salarying/Corporation/User/entity/Member.java
+++ b/salarying/src/main/java/com/example/salarying/Corporation/User/entity/Member.java
@@ -72,8 +72,9 @@ public class Member {
         this.role = role;
     }
 
-    public void encodePassword(PasswordEncoder passwordEncoder) {
+    public void encodePassword(PasswordEncoder passwordEncoder, Admin admin) {
         password = passwordEncoder.encode(password);
+        this.admin = admin;
         this.lastModified = new Date();
     }
 

--- a/salarying/src/main/java/com/example/salarying/Corporation/User/repository/MemberRepository.java
+++ b/salarying/src/main/java/com/example/salarying/Corporation/User/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findById(Long Id);
+
+    Long countByAdmin_Id(Long Id);
 }

--- a/salarying/src/main/java/com/example/salarying/Corporation/User/service/MemberServiceImpl.java
+++ b/salarying/src/main/java/com/example/salarying/Corporation/User/service/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.salarying.Corporation.User.service;
 
+import com.example.salarying.Admin.User.entity.Admin;
+import com.example.salarying.Admin.User.repository.AdminRepository;
 import com.example.salarying.Corporation.User.dto.MemberDTO;
 import com.example.salarying.Corporation.User.entity.Member;
 import com.example.salarying.Corporation.User.exception.UserException;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class MemberServiceImpl implements MemberService{
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthTokenProvider authTokenProvider;
+    private final AdminRepository adminRepository;
 
     /**
      * 사용자 정보를 확인하여 비밀번호 암호화 수행 후 DB에 저장
@@ -34,7 +38,8 @@ public class MemberServiceImpl implements MemberService{
 
         if(checkFormat(request) && memberRepository.findByEmail(request.getEmail()).isEmpty()){
             Member newMember = request.toEntity();
-            newMember.encodePassword(passwordEncoder);
+            Admin admin = findAdmin();
+            newMember.encodePassword(passwordEncoder, admin);
             memberRepository.save(newMember);
             return newMember;
         }
@@ -60,6 +65,17 @@ public class MemberServiceImpl implements MemberService{
         } else{
             return true;
         }
+    }
+
+    public Admin findAdmin(){
+        List<Admin> adminList = adminRepository.findAllByRole("ADMIN");
+        for(Admin admin : adminList){
+            if(memberRepository.countByAdmin_Id(admin.getId()) < 5){
+                return admin;
+            }
+        }
+        Admin superAdmin = adminRepository.findByRole("SUPERADMIN");
+        return superAdmin;
     }
 
 


### PR DESCRIPTION
## Why need this change? 
- #69 

## Changes ✏️
-  3f9af74620511aa7b83645acd3b1b2b5fa17fa55 : 모든 관리자 조회 및 슈퍼 관리자 찾는 함수 추가
- baf6570425e42d4c86b99ad7cbffaa28332934e6 : 비밀번호 암호화 시 관리자 배정 업데이트 추가
- affa8db4ad0d2394aff7ae1b7508a9e95c01abfa : 관리자 배정을 위해 관리자 별 담당 기업 카운트 함수 추가
- e6dcc0cdade9b3a5ccc42bcbaa22bde705bcae11 : 회원가입 시 관리자 별 담당기업 수를 조회하여 자동으로 관리자를 배정하는 로직 구현

## Test checklist✅ (optional)
- 테스트완료
